### PR TITLE
Catch exceptions in the only handling

### DIFF
--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -24,6 +24,7 @@ import sphinx
 from docutils.parsers.rst import directives
 from sphinx.util import logging
 
+
 class EagerOnly(sphinx.directives.other.Only):
 
     def run(self, *args):
@@ -38,6 +39,7 @@ class EagerOnly(sphinx.directives.other.Only):
             logger = logging.getLogger(__name__)
             logger.warning(('exception while evaluating only directive expression: %s'), err,
                             location=(self.env.docname, self.lineno))
+            raise
         # Otherwise, do the usual processing
         nodes = super(EagerOnly, self).run()
         if len(nodes) == 1:

--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -36,10 +36,9 @@ class EagerOnly(sphinx.directives.other.Only):
             if not env.app.builder.tags.eval_condition(self.arguments[0]):
                 return []
         except Exception as err:
-            logger = sphinx.util.logging.getLogger(__name__)
-            logger.warning("exception while evaluating 'only' directive expression: %s", err,
+            logger.critical("Exception while evaluating 'only' directive expression: %r", err,
                             location=(self.env.docname, self.lineno))
-            raise
+            raise err
         # Otherwise, do the usual processing
         nodes = super(EagerOnly, self).run()
         if len(nodes) == 1:

--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -25,6 +25,9 @@ from docutils.parsers.rst import directives
 from sphinx.util import logging
 
 
+logger = sphinx.util.logging.getLogger(__name__)
+
+
 class EagerOnly(sphinx.directives.other.Only):
 
     def run(self, *args):

--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -37,7 +37,7 @@ class EagerOnly(sphinx.directives.other.Only):
                 return []
         except Exception as err:
             logger = logging.getLogger(__name__)
-            logger.warning(('exception while evaluating only directive expression: %s'), err,
+            logger.warning("exception while evaluating 'only' directive expression: %s", err,
                             location=(self.env.docname, self.lineno))
             raise
         # Otherwise, do the usual processing

--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -22,7 +22,7 @@
 #
 import sphinx
 from docutils.parsers.rst import directives
-
+from sphinx.util import logging
 
 class EagerOnly(sphinx.directives.other.Only):
 
@@ -31,9 +31,13 @@ class EagerOnly(sphinx.directives.other.Only):
         env = self.state.document.settings.env
         env.app.builder.tags.add('TRUE')
         #print(repr(self.arguments[0]))
-        if not env.app.builder.tags.eval_condition(self.arguments[0]):
-            return []
-
+        try:
+            if not env.app.builder.tags.eval_condition(self.arguments[0]):
+                return []
+        except Exception as err:
+            logger = logging.getLogger(__name__)
+            logger.warning(('exception while evaluating only directive expression: %s'), err,
+                            location=(self.env.docname, self.lineno))
         # Otherwise, do the usual processing
         nodes = super(EagerOnly, self).run()
         if len(nodes) == 1:

--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -36,7 +36,7 @@ class EagerOnly(sphinx.directives.other.Only):
             if not env.app.builder.tags.eval_condition(self.arguments[0]):
                 return []
         except Exception as err:
-            logger = logging.getLogger(__name__)
+            logger = sphinx.util.logging.getLogger(__name__)
             logger.warning("exception while evaluating 'only' directive expression: %s", err,
                             location=(self.env.docname, self.lineno))
             raise


### PR DESCRIPTION
Give rst line and file information upon exceptions in sphinx_selective_exclude

Example syntax error:
```
.. someItem

.. only:: whenSomethingEnabled
       someItemSometime
```
With this fix the exception info:
```
/home/dev/mysphynx/index.rst:15: WARNING: exception while evaluating 'only' directive expression: chunk after expression  
```

Fixes https://github.com/pfalcon/sphinx_selective_exclude/issues/6