### PR TITLE
Mark directives as parallel read & write safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 PROJECT_URL = 'https://github.com/pfalcon/sphinx_selective_exclude'
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 setup(
     name='sphinx_selective_exclude',

--- a/sphinx_selective_exclude/eager_only.py
+++ b/sphinx_selective_exclude/eager_only.py
@@ -43,3 +43,5 @@ class EagerOnly(sphinx.directives.other.Only):
 
 def setup(app):
     directives.register_directive('only', EagerOnly)
+
+    return {'parallel_read_safe': True, 'parallel_write_safe': True, 'version': '1.0.2'}

--- a/sphinx_selective_exclude/modindex_exclude.py
+++ b/sphinx_selective_exclude/modindex_exclude.py
@@ -73,3 +73,5 @@ def setup(app):
     global org_PyModule_run
     org_PyModule_run = sphinx.domains.python.PyModule.run
     sphinx.domains.python.PyModule.run = PyModule_run
+
+    return {'parallel_read_safe': True, 'parallel_write_safe': True, 'version': '1.0.2'}

--- a/sphinx_selective_exclude/search_auto_exclude.py
+++ b/sphinx_selective_exclude/search_auto_exclude.py
@@ -32,3 +32,5 @@ def setup(app):
     global org_StandaloneHTMLBuilder_index_page
     org_StandaloneHTMLBuilder_index_page = sphinx.builders.html.StandaloneHTMLBuilder.index_page
     sphinx.builders.html.StandaloneHTMLBuilder.index_page = StandaloneHTMLBuilder_index_page
+
+    return {'parallel_read_safe': True, 'parallel_write_safe': True, 'version': '1.0.2'}


### PR DESCRIPTION
Hi @pfalcon,

I've started using the eager_only extension while improving our docs builds, it's very helpful. Thanks for publishing it.

At the moment these extensions cause Sphinx to disable parallel read/write jobs. I believe that feature was added to Sphinx since the initial development of these extensions.

This PR adds the extension metadata that Sphinx looks for to allow parallel jobs.

Currently only eager_only has been tested with a parallel Sphinx build (Sphinx 1.8.5), but none of the extensions have any runtime dependency on other pages or page processing order, so suggest it's fairly safe to mark them all parallel read & write safe. However if you prefer I can amend the commit to only enable it for that extension.